### PR TITLE
update: Bump PostCSS dep to postcss 8.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,82 +1,56 @@
 {
 	"name": "google-fonts-complete",
-	"version": "1.2.4",
+	"version": "2.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+		"colorette": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+			"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
 			"requires": {
-				"color-convert": "^1.9.0"
+				"isarray": "1.0.0"
 			}
 		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+		"line-column": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
+			"integrity": "sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=",
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"dependencies": {
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"isarray": "^1.0.0",
+				"isobject": "^2.0.0"
 			}
 		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		"nanoid": {
+			"version": "3.1.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.16.tgz",
+			"integrity": "sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w=="
 		},
 		"postcss": {
-			"version": "7.0.18",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
-			"integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
+			"version": "8.1.7",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.1.7.tgz",
+			"integrity": "sha512-llCQW1Pz4MOPwbZLmOddGM9eIJ8Bh7SZ2Oj5sxZva77uVaotYDsYTch1WBTNu7fUY0fpWp0fdt7uW40D4sRiiQ==",
 			"requires": {
-				"chalk": "^2.4.2",
-				"source-map": "^0.6.1",
-				"supports-color": "^6.1.0"
+				"colorette": "^1.2.1",
+				"line-column": "^1.0.2",
+				"nanoid": "^3.1.16",
+				"source-map": "^0.6.1"
 			}
 		},
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-		},
-		"supports-color": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-			"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/jonathantneal/google-fonts-complete.git"
   },
   "dependencies": {
-    "postcss": "^7.0.18"
+    "postcss": "^8.1.7"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Reduce the number of different PostCSS version installed with postcss-font-magician.

Since p[ostcss-font-magician](https://github.com/jonathantneal/postcss-font-magician) depends on this package, now that postcss-font-magician uses PostCSS 8, installing it causes two versions of PostCSS to be installed. So this pull request brings the PostCSS versions in line.

As a check, I've run `google-fonts-generator` with the updated PostCSS and the output is the same apart from the font versions numbers.

I thought of moving PostCSS to the `devDependencies` since it's only used in `google-fonts-generator.js`, but I thought maybe someone is relying on the fact that installing this package would also install PostCSS.